### PR TITLE
Fix ORIGDIR variable

### DIFF
--- a/common/functions.sh
+++ b/common/functions.sh
@@ -121,7 +121,7 @@ ui_print " "
 [ -z $DYNLIB ] && DYNLIB=false
 [ -z $DEBUG ] && DEBUG=false
 INFO=$NVBASE/modules/.$MODID-files
-ORIGDIR="$MAGISKTMP/mirror"
+ORIGDIR="$MAGISKTMP/.magisk/mirror"
 if $DYNLIB; then
   LIBPATCH="\/vendor"
   LIBDIR=/system/vendor


### PR DESCRIPTION
ORIGDIR points to non-existing directory, because `.magisk` sub-dir is missing (compare [MAGISKTMP and INTERNALDIR]( https://topjohnwu.github.io/Magisk/details.html#paths-in-magisk-tmpfs-directory)). [Wiki](https://github.com/Zackptg5/MMT-Extended/wiki/Variables) is also wrong about MAGISKTMP content (it doesn't contain `.magisk` part).

This is the reason why JamesDSP force closes when installed via Magisk module.